### PR TITLE
Forward capability retrieval calls to the super method. Closes #1

### DIFF
--- a/main/java/ghostwolf/simplyloaders/entities/EntityMinecartTank.java
+++ b/main/java/ghostwolf/simplyloaders/entities/EntityMinecartTank.java
@@ -49,7 +49,7 @@ public class EntityMinecartTank extends EntityMinecart {
 		if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
 			return (T) this.tank;
 		}
-		return null;
+		return super.getCapability(capability, facing);
 	}
 	
 	@Override
@@ -57,7 +57,7 @@ public class EntityMinecartTank extends EntityMinecart {
 		if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
 			return true;
 		} else {
-			return false;
+			return super.hasCapability(capability, facing);
 		}
 	}
 	


### PR DESCRIPTION
This allows other mod's capabilities to be retrieved, resolving https://github.com/theredghostwolf/SimplyLoaders-V2/issues/1
This fix is in line of how this is done in the vanilla+forge code base, for example look at EntityMinecartContainer.java.